### PR TITLE
fix: replacing deprecated set-output in workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,7 +23,7 @@ jobs:
       id: variables
       run: |
         VERSION=${GITHUB_REF#refs/tags/}
-        echo ::set-output name=VERSION::$VERSION
+        echo VERSION=$VERSION >> $GITHUB_OUTPUT
         
     - name: Test project
       run: |


### PR DESCRIPTION
Replacing deprecated `set-output` to use env `$GITHUB_OUTPUT` instead.

Blogg post about deprecation:
https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/