### PR TITLE
Looking back and forward 24 hours in the Monta API

### DIFF
--- a/TeslaMateAgile.Tests/Services/MontaServiceTests.cs
+++ b/TeslaMateAgile.Tests/Services/MontaServiceTests.cs
@@ -56,7 +56,9 @@ namespace TeslaMateAgile.Tests.Services
             _handler.SetupRequest(HttpMethod.Post, "https://public-api.monta.com/api/v1/auth/token")
                 .ReturnsResponse(JsonSerializer.Serialize(accessTokenResponse), "application/json");
 
-            _handler.SetupRequest(HttpMethod.Get, $"https://public-api.monta.com/api/v1/charges?state=completed&fromDate={from.UtcDateTime:o}&toDate={to.UtcDateTime:o}&chargePointId=123")
+            var fromDate = from.AddHours(MontaService.FetchHoursBeforeFrom).UtcDateTime;
+            var toDate = to.AddHours(MontaService.FetchHoursAfterTo).UtcDateTime;
+            _handler.SetupRequest(HttpMethod.Get, $"https://public-api.monta.com/api/v1/charges?state=completed&fromDate={fromDate:o}&toDate={toDate:o}&chargePointId=123")
                 .ReturnsResponse(JsonSerializer.Serialize(chargesResponse), "application/json");
 
             var charges = await _subject.GetCharges(from, to);
@@ -103,7 +105,9 @@ namespace TeslaMateAgile.Tests.Services
             _handler.SetupRequest(HttpMethod.Post, "https://public-api.monta.com/api/v1/auth/token")
                 .ReturnsResponse(JsonSerializer.Serialize(accessTokenResponse), "application/json");
 
-            _handler.SetupRequest(HttpMethod.Get, $"https://public-api.monta.com/api/v1/charges?state=completed&fromDate={from.UtcDateTime:o}&toDate={to.UtcDateTime:o}")
+            var fromDate = from.AddHours(MontaService.FetchHoursBeforeFrom).UtcDateTime;
+            var toDate = to.AddHours(MontaService.FetchHoursAfterTo).UtcDateTime;
+            _handler.SetupRequest(HttpMethod.Get, $"https://public-api.monta.com/api/v1/charges?state=completed&fromDate={fromDate:o}&toDate={toDate:o}")
                 .ReturnsResponse(JsonSerializer.Serialize(chargesResponse), "application/json");
 
             var charges = await _subject.GetCharges(from, to);

--- a/TeslaMateAgile/Services/MontaService.cs
+++ b/TeslaMateAgile/Services/MontaService.cs
@@ -53,6 +53,9 @@ namespace TeslaMateAgile.Services
 
         private async Task<Charge[]> GetCharges(string accessToken, DateTimeOffset from, DateTimeOffset to)
         {
+            from = from.AddHours(-24);
+            to = to.AddHours(24);
+            
             var requestUri = $"{_options.BaseUrl}/charges?state=completed&fromDate={from.UtcDateTime:o}&toDate={to.UtcDateTime:o}";
             if (_options.ChargePointId.HasValue)
             {

--- a/TeslaMateAgile/Services/MontaService.cs
+++ b/TeslaMateAgile/Services/MontaService.cs
@@ -13,6 +13,9 @@ namespace TeslaMateAgile.Services
         private readonly HttpClient _client;
         private readonly MontaOptions _options;
 
+        public const int FetchHoursBeforeFrom = -24;
+        public const int FetchHoursAfterTo = 24;
+
         public MontaService(HttpClient client, IOptions<MontaOptions> options)
         {
             _client = client;
@@ -53,8 +56,8 @@ namespace TeslaMateAgile.Services
 
         private async Task<Charge[]> GetCharges(string accessToken, DateTimeOffset from, DateTimeOffset to)
         {
-            from = from.AddHours(-24);
-            to = to.AddHours(24);
+            from = from.AddHours(FetchHoursBeforeFrom);
+            to = to.AddHours(FetchHoursAfterTo);
             
             var requestUri = $"{_options.BaseUrl}/charges?state=completed&fromDate={from.UtcDateTime:o}&toDate={to.UtcDateTime:o}";
             if (_options.ChargePointId.HasValue)


### PR DESCRIPTION
The code changes seem almost too simple. Should I put the 24 hours in variables like the new `MatchingXToleranceMinutes`?

Tested on my own data from the last 90 days, with only one failed calculation (edge-case, see more below).

#

The failed calculation is a super edge-case where the charge failed (for unknown reasons) at 67% and I continued it later in the app where it failed again!! after 8 minutes and I continued again. This yields 2 charges from the Monta API.
Just to make it clear, I don't think TeslaMateAgile should try to handle edge-cases like this, I just added it out of interest. 

<img width="1414" alt="image" src="https://github.com/user-attachments/assets/da8fe01d-7a02-47ac-8f4c-86fae89f7c3d">

```json
{
    "data": [
        {
            "id": 123,
            "chargePointId": 123,
            "createdAt": "2024-08-15T07:23:00Z",
            "updatedAt": "2024-08-15T11:59:08Z",
            "cablePluggedInAt": "2024-08-15T07:23:00Z",
            "startedAt": "2024-08-15T07:23:00Z",
            "stoppedAt": "2024-08-15T11:59:03Z",
            "fullyChargedAt": null,
            "failedAt": null,
            "timeoutAt": null,
            "state": "completed",
            "consumedKwh": 50.52,
            "kwhLimit": null,
            "startMeterKwh": 7955.649,
            "endMeterKwh": 8006.167,
            "cost": 12.17,
            "price": 105.01,
            "priceLimit": null,
            "averagePricePerKwh": 2.08,
            "averageCo2PerKwh": 137.83,
            "averageRenewablePerKwh": 81.73,
            "failureReason": null,
            "stopReason": "fully charged",
            "note": null,
            "currency": {
                "identifier": "dkk",
                "name": "Danish kroner",
                "decimals": 2
            },
            "soc": null,
            "socLimit": null
        },
        {
            "id": 123,
            "chargePointId": 123,
            "createdAt": "2024-08-15T07:22:22Z",
            "updatedAt": "2024-08-15T07:22:29Z",
            "cablePluggedInAt": "2024-08-15T07:22:22Z",
            "startedAt": "2024-08-15T07:22:22Z",
            "stoppedAt": "2024-08-15T07:22:25Z",
            "fullyChargedAt": null,
            "failedAt": null,
            "timeoutAt": null,
            "state": "completed",
            "consumedKwh": 0.0,
            "kwhLimit": null,
            "startMeterKwh": 7955.649,
            "endMeterKwh": 7955.649,
            "cost": 0,
            "price": 0,
            "priceLimit": null,
            "averagePricePerKwh": 0,
            "averageCo2PerKwh": 0.0,
            "averageRenewablePerKwh": 0.0,
            "failureReason": null,
            "stopReason": "regular state change",
            "note": null,
            "currency": {
                "identifier": "dkk",
                "name": "Danish kroner",
                "decimals": 2
            },
            "soc": null,
            "socLimit": null
        }
    ],
    "meta": {
        "itemCount": 2,
        "currentPage": 0,
        "perPage": 10,
        "totalPageCount": 1,
        "totalItemCount": 2
    }
}
```