### PR TITLE
Add support for FixedPriceWeekly provider

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,6 @@
+{
+  "tasks": {
+    "build": "dotnet build",
+    "test": "dotnet test"
+  }
+}

--- a/README.md
+++ b/README.md
@@ -61,6 +61,8 @@ See below for how to configure the environment variables appropriately
 
 ### Fixed Price
 
+The Fixed Price provider allows you to use TeslaMateAgile if you have a fixed price for electricity at different times of the day. This is useful if you have a simple time-of-use tariff that isn't supported by the other providers.
+
 ```yaml
 - TeslaMate__EnergyProvider=FixedPrice
 - FixedPrice__TimeZone=Europe/London # IANA (tz database) time zone code, used for below times 
@@ -69,6 +71,23 @@ See below for how to configure the environment variables appropriately
 - FixedPrice__Prices__2=20:00-03:30=0.04
 - FixedPrice__Prices__3=03:30-06:00=0.035
 - FixedPrice__Prices__4=06:00-08:00=0.02
+```
+
+### Fixed Price (Weekly)
+
+The Fixed Price Weekly provider is similar to the Fixed Price provider but allows you to set different prices for different days of the week. This is useful if your electricity tariff changes on different days of the week but is consistent week-to-week, e.g. a weekday / weekend tariff.
+
+```yaml
+- TeslaMate__EnergyProvider=FixedPriceWeekly
+- FixedPriceWeekly__TimeZone=Europe/London # IANA (tz database) time zone code, used for below times
+- FixedPriceWeekly__Prices__0=Mon-Wed=08:00-13:00=0.1559 # Cost is in your currency e.g. pounds, euros, dollars (not pennies, cents, etc)
+- FixedPriceWeekly__Prices__1=Mon-Wed=13:00-08:00=0.05 # Day(s) of the week can be comma separated or a range (e.g. Mon-Fri or Mon,Wed,Fri)
+- FixedPriceWeekly__Prices__6=Thu=0.22 # The time range is optional and will be used for the whole day if unspecified
+- FixedPriceWeekly__Prices__3=Fri,Sat=08:00-18:00=0.1559 # You can have as many as these as you need
+- FixedPriceWeekly__Prices__4=Fri,Sat=18:00-08:00=0.04
+- FixedPriceWeekly__Prices__5=Sun=12:00-18:00=0.1559
+- FixedPriceWeekly__Prices__7=Sun=18:00-08:00=0.04
+- FixedPriceWeekly__Prices__8=Sun=08:00-12:00=0.1559
 ```
 
 ### aWATTar

--- a/TeslaMateAgile.Tests/Services/FixedPriceWeeklyServiceTests.cs
+++ b/TeslaMateAgile.Tests/Services/FixedPriceWeeklyServiceTests.cs
@@ -122,6 +122,46 @@ namespace TeslaMateAgile.Tests.Services
             },
             new object[]
             {
+                "CommaSeparatedDays",
+                "Europe/London",
+                new List<string>
+                {
+                    "Mon-Wed=08:00-13:00=0.1559",
+                    "Mon-Wed=13:00-20:00=0.05",
+                    "Mon-Wed=20:00-08:00=0.04",
+                    "Thu,Fri=08:00-18:00=0.1559",
+                    "Thu,Fri=18:00-08:00=0.04",
+                    "Sat=04:00-08:00=0.035",
+                    "Sat=08:00-13:00=0.02",
+                    "Sat=13:00-04:00=0.05",
+                    "Sun=0.22"
+                },
+                new DateTimeOffset(new DateTime(2023, 1, 4, 2, 0, 0, DateTimeKind.Utc)), // Wed
+                new DateTimeOffset(new DateTime(2023, 1, 7, 4, 0, 0, DateTimeKind.Utc)), // Sat
+                new List<Price>
+                {
+                    // Wednesday
+                    new() { ValidFrom = new DateTimeOffset(new DateTime(2023, 1, 4, 0, 0, 0, DateTimeKind.Utc)), ValidTo = new DateTimeOffset(new DateTime(2023, 1, 4, 8, 0, 0, DateTimeKind.Utc)), Value = 0.04m },
+                    new() { ValidFrom = new DateTimeOffset(new DateTime(2023, 1, 4, 8, 0, 0, DateTimeKind.Utc)), ValidTo = new DateTimeOffset(new DateTime(2023, 1, 4, 13, 0, 0, DateTimeKind.Utc)), Value = 0.1559m },
+                    new() { ValidFrom = new DateTimeOffset(new DateTime(2023, 1, 4, 13, 0, 0, DateTimeKind.Utc)), ValidTo = new DateTimeOffset(new DateTime(2023, 1, 4, 20, 0, 0, DateTimeKind.Utc)), Value = 0.05m },
+                    new() { ValidFrom = new DateTimeOffset(new DateTime(2023, 1, 4, 20, 0, 0, DateTimeKind.Utc)), ValidTo = new DateTimeOffset(new DateTime(2023, 1, 5, 0, 0, 0, DateTimeKind.Utc)), Value = 0.04m },
+
+                    // Thursday
+                    new() { ValidFrom = new DateTimeOffset(new DateTime(2023, 1, 5, 0, 0, 0, DateTimeKind.Utc)), ValidTo = new DateTimeOffset(new DateTime(2023, 1, 5, 8, 0, 0, DateTimeKind.Utc)), Value = 0.04m },
+                    new() { ValidFrom = new DateTimeOffset(new DateTime(2023, 1, 5, 8, 0, 0, DateTimeKind.Utc)), ValidTo = new DateTimeOffset(new DateTime(2023, 1, 5, 18, 0, 0, DateTimeKind.Utc)), Value = 0.1559m },
+                    new() { ValidFrom = new DateTimeOffset(new DateTime(2023, 1, 5, 18, 0, 0, DateTimeKind.Utc)), ValidTo = new DateTimeOffset(new DateTime(2023, 1, 6, 0, 0, 0, DateTimeKind.Utc)), Value = 0.04m },
+
+                    // Friday
+                    new() { ValidFrom = new DateTimeOffset(new DateTime(2023, 1, 6, 0, 0, 0, DateTimeKind.Utc)), ValidTo = new DateTimeOffset(new DateTime(2023, 1, 6, 8, 0, 0, DateTimeKind.Utc)), Value = 0.04m },
+                    new() { ValidFrom = new DateTimeOffset(new DateTime(2023, 1, 6, 8, 0, 0, DateTimeKind.Utc)), ValidTo = new DateTimeOffset(new DateTime(2023, 1, 6, 18, 0, 0, DateTimeKind.Utc)), Value = 0.1559m },
+                    new() { ValidFrom = new DateTimeOffset(new DateTime(2023, 1, 6, 18, 0, 0, DateTimeKind.Utc)), ValidTo = new DateTimeOffset(new DateTime(2023, 1, 7, 0, 0, 0, DateTimeKind.Utc)), Value = 0.04m },
+
+                    // Saturday
+                    new() { ValidFrom = new DateTimeOffset(new DateTime(2023, 1, 7, 0, 0, 0, DateTimeKind.Utc)), ValidTo = new DateTimeOffset(new DateTime(2023, 1, 7, 4, 0, 0, DateTimeKind.Utc)), Value = 0.05m }
+                }
+            },
+            new object[]
+            {
                 "DifferentTimeZone",
                 "America/New_York",
                 new List<string>

--- a/TeslaMateAgile.Tests/Services/FixedPriceWeeklyServiceTests.cs
+++ b/TeslaMateAgile.Tests/Services/FixedPriceWeeklyServiceTests.cs
@@ -1,5 +1,6 @@
 using Microsoft.Extensions.Options;
 using NUnit.Framework;
+using NUnit.Framework.Internal;
 using TeslaMateAgile.Data;
 using TeslaMateAgile.Data.Options;
 using TeslaMateAgile.Services;
@@ -7,7 +8,7 @@ using TeslaMateAgile.Services;
 namespace TeslaMateAgile.Tests.Services
 {
     [TestFixture]
-    public class FixedPriceWeeklyServiceTestsTest
+    public class FixedPriceWeeklyServiceTests
     {
         private FixedPriceWeeklyService Setup(string timeZone, List<string> prices)
         {
@@ -19,7 +20,7 @@ namespace TeslaMateAgile.Tests.Services
         {
             new object[]
             {
-                "WeekdaysAndWeekend",
+                "MondayToNextTuesday",
                 "Europe/London",
                 new List<string>
                 {
@@ -36,7 +37,7 @@ namespace TeslaMateAgile.Tests.Services
                 new DateTimeOffset(new DateTime(2023, 1, 10, 4, 0, 0, DateTimeKind.Utc)), // Next Tuesday
                 new List<Price>
                 {
-                    // Monday prices from 2am
+                    // Monday from 2am
                     new() { ValidFrom = new DateTimeOffset(new DateTime(2023, 1, 2, 0, 0, 0, DateTimeKind.Utc)), ValidTo = new DateTimeOffset(new DateTime(2023, 1, 2, 3, 30, 0, DateTimeKind.Utc)), Value = 0.04m },
                     new() { ValidFrom = new DateTimeOffset(new DateTime(2023, 1, 2, 3, 30, 0, DateTimeKind.Utc)), ValidTo = new DateTimeOffset(new DateTime(2023, 1, 2, 6, 0, 0, DateTimeKind.Utc)), Value = 0.035m },
                     new() { ValidFrom = new DateTimeOffset(new DateTime(2023, 1, 2, 6, 0, 0, DateTimeKind.Utc)), ValidTo = new DateTimeOffset(new DateTime(2023, 1, 2, 8, 0, 0, DateTimeKind.Utc)), Value = 0.02m },
@@ -44,7 +45,7 @@ namespace TeslaMateAgile.Tests.Services
                     new() { ValidFrom = new DateTimeOffset(new DateTime(2023, 1, 2, 13, 0, 0, DateTimeKind.Utc)), ValidTo = new DateTimeOffset(new DateTime(2023, 1, 2, 20, 0, 0, DateTimeKind.Utc)), Value = 0.05m },
                     new() { ValidFrom = new DateTimeOffset(new DateTime(2023, 1, 2, 20, 0, 0, DateTimeKind.Utc)), ValidTo = new DateTimeOffset(new DateTime(2023, 1, 3, 0, 0, 0, DateTimeKind.Utc)), Value = 0.04m },
 
-                    // Tuesday prices
+                    // Tuesday
                     new() { ValidFrom = new DateTimeOffset(new DateTime(2023, 1, 3, 0, 0, 0, DateTimeKind.Utc)), ValidTo = new DateTimeOffset(new DateTime(2023, 1, 3, 3, 30, 0, DateTimeKind.Utc)), Value = 0.04m },
                     new() { ValidFrom = new DateTimeOffset(new DateTime(2023, 1, 3, 3, 30, 0, DateTimeKind.Utc)), ValidTo = new DateTimeOffset(new DateTime(2023, 1, 3, 6, 0, 0, DateTimeKind.Utc)), Value = 0.035m },
                     new() { ValidFrom = new DateTimeOffset(new DateTime(2023, 1, 3, 6, 0, 0, DateTimeKind.Utc)), ValidTo = new DateTimeOffset(new DateTime(2023, 1, 3, 8, 0, 0, DateTimeKind.Utc)), Value = 0.02m },
@@ -52,7 +53,7 @@ namespace TeslaMateAgile.Tests.Services
                     new() { ValidFrom = new DateTimeOffset(new DateTime(2023, 1, 3, 13, 0, 0, DateTimeKind.Utc)), ValidTo = new DateTimeOffset(new DateTime(2023, 1, 3, 20, 0, 0, DateTimeKind.Utc)), Value = 0.05m },
                     new() { ValidFrom = new DateTimeOffset(new DateTime(2023, 1, 3, 20, 0, 0, DateTimeKind.Utc)), ValidTo = new DateTimeOffset(new DateTime(2023, 1, 4, 0, 0, 0, DateTimeKind.Utc)), Value = 0.04m },
 
-                    // Wednesday prices
+                    // Wednesday
                     new() { ValidFrom = new DateTimeOffset(new DateTime(2023, 1, 4, 0, 0, 0, DateTimeKind.Utc)), ValidTo = new DateTimeOffset(new DateTime(2023, 1, 4, 3, 30, 0, DateTimeKind.Utc)), Value = 0.04m },
                     new() { ValidFrom = new DateTimeOffset(new DateTime(2023, 1, 4, 3, 30, 0, DateTimeKind.Utc)), ValidTo = new DateTimeOffset(new DateTime(2023, 1, 4, 6, 0, 0, DateTimeKind.Utc)), Value = 0.035m },
                     new() { ValidFrom = new DateTimeOffset(new DateTime(2023, 1, 4, 6, 0, 0, DateTimeKind.Utc)), ValidTo = new DateTimeOffset(new DateTime(2023, 1, 4, 8, 0, 0, DateTimeKind.Utc)), Value = 0.02m },
@@ -60,7 +61,7 @@ namespace TeslaMateAgile.Tests.Services
                     new() { ValidFrom = new DateTimeOffset(new DateTime(2023, 1, 4, 13, 0, 0, DateTimeKind.Utc)), ValidTo = new DateTimeOffset(new DateTime(2023, 1, 4, 20, 0, 0, DateTimeKind.Utc)), Value = 0.05m },
                     new() { ValidFrom = new DateTimeOffset(new DateTime(2023, 1, 4, 20, 0, 0, DateTimeKind.Utc)), ValidTo = new DateTimeOffset(new DateTime(2023, 1, 5, 0, 0, 0, DateTimeKind.Utc)), Value = 0.04m },
 
-                    // Thursday prices
+                    // Thursday
                     new() { ValidFrom = new DateTimeOffset(new DateTime(2023, 1, 5, 0, 0, 0, DateTimeKind.Utc)), ValidTo = new DateTimeOffset(new DateTime(2023, 1, 5, 3, 30, 0, DateTimeKind.Utc)), Value = 0.04m },
                     new() { ValidFrom = new DateTimeOffset(new DateTime(2023, 1, 5, 3, 30, 0, DateTimeKind.Utc)), ValidTo = new DateTimeOffset(new DateTime(2023, 1, 5, 6, 0, 0, DateTimeKind.Utc)), Value = 0.035m },
                     new() { ValidFrom = new DateTimeOffset(new DateTime(2023, 1, 5, 6, 0, 0, DateTimeKind.Utc)), ValidTo = new DateTimeOffset(new DateTime(2023, 1, 5, 8, 0, 0, DateTimeKind.Utc)), Value = 0.02m },
@@ -68,7 +69,7 @@ namespace TeslaMateAgile.Tests.Services
                     new() { ValidFrom = new DateTimeOffset(new DateTime(2023, 1, 5, 13, 0, 0, DateTimeKind.Utc)), ValidTo = new DateTimeOffset(new DateTime(2023, 1, 5, 20, 0, 0, DateTimeKind.Utc)), Value = 0.05m },
                     new() { ValidFrom = new DateTimeOffset(new DateTime(2023, 1, 5, 20, 0, 0, DateTimeKind.Utc)), ValidTo = new DateTimeOffset(new DateTime(2023, 1, 6, 0, 0, 0, DateTimeKind.Utc)), Value = 0.04m },
 
-                    // Friday prices
+                    // Friday
                     new() { ValidFrom = new DateTimeOffset(new DateTime(2023, 1, 6, 0, 0, 0, DateTimeKind.Utc)), ValidTo = new DateTimeOffset(new DateTime(2023, 1, 6, 3, 30, 0, DateTimeKind.Utc)), Value = 0.04m },
                     new() { ValidFrom = new DateTimeOffset(new DateTime(2023, 1, 6, 3, 30, 0, DateTimeKind.Utc)), ValidTo = new DateTimeOffset(new DateTime(2023, 1, 6, 6, 0, 0, DateTimeKind.Utc)), Value = 0.035m },
                     new() { ValidFrom = new DateTimeOffset(new DateTime(2023, 1, 6, 6, 0, 0, DateTimeKind.Utc)), ValidTo = new DateTimeOffset(new DateTime(2023, 1, 6, 8, 0, 0, DateTimeKind.Utc)), Value = 0.02m },
@@ -76,15 +77,15 @@ namespace TeslaMateAgile.Tests.Services
                     new() { ValidFrom = new DateTimeOffset(new DateTime(2023, 1, 6, 13, 0, 0, DateTimeKind.Utc)), ValidTo = new DateTimeOffset(new DateTime(2023, 1, 6, 20, 0, 0, DateTimeKind.Utc)), Value = 0.05m },
                     new() { ValidFrom = new DateTimeOffset(new DateTime(2023, 1, 6, 20, 0, 0, DateTimeKind.Utc)), ValidTo = new DateTimeOffset(new DateTime(2023, 1, 7, 0, 0, 0, DateTimeKind.Utc)), Value = 0.04m },
 
-                    // Saturday prices
+                    // Saturday
                     new() { ValidFrom = new DateTimeOffset(new DateTime(2023, 1, 7, 0, 0, 0, DateTimeKind.Utc)), ValidTo = new DateTimeOffset(new DateTime(2023, 1, 7, 18, 0, 0, DateTimeKind.Utc)), Value = 0.025m },
                     new() { ValidFrom = new DateTimeOffset(new DateTime(2023, 1, 7, 18, 0, 0, DateTimeKind.Utc)), ValidTo = new DateTimeOffset(new DateTime(2023, 1, 7, 20, 0, 0, DateTimeKind.Utc)), Value = 0.05m },
                     new() { ValidFrom = new DateTimeOffset(new DateTime(2023, 1, 7, 20, 0, 0, DateTimeKind.Utc)), ValidTo = new DateTimeOffset(new DateTime(2023, 1, 8, 0, 0, 0, DateTimeKind.Utc)), Value = 0.025m },
 
-                    // Sunday prices
+                    // Sunday
                     new() { ValidFrom = new DateTimeOffset(new DateTime(2023, 1, 8, 0, 0, 0, DateTimeKind.Utc)), ValidTo = new DateTimeOffset(new DateTime(2023, 1, 9, 0, 0, 0, DateTimeKind.Utc)), Value = 0.042m },
 
-                    // Monday prices
+                    // Monday
                     new() { ValidFrom = new DateTimeOffset(new DateTime(2023, 1, 9, 0, 0, 0, DateTimeKind.Utc)), ValidTo = new DateTimeOffset(new DateTime(2023, 1, 9, 3, 30, 0, DateTimeKind.Utc)), Value = 0.04m },
                     new() { ValidFrom = new DateTimeOffset(new DateTime(2023, 1, 9, 3, 30, 0, DateTimeKind.Utc)), ValidTo = new DateTimeOffset(new DateTime(2023, 1, 9, 6, 0, 0, DateTimeKind.Utc)), Value = 0.035m },
                     new() { ValidFrom = new DateTimeOffset(new DateTime(2023, 1, 9, 6, 0, 0, DateTimeKind.Utc)), ValidTo = new DateTimeOffset(new DateTime(2023, 1, 9, 8, 0, 0, DateTimeKind.Utc)), Value = 0.02m },
@@ -92,9 +93,110 @@ namespace TeslaMateAgile.Tests.Services
                     new() { ValidFrom = new DateTimeOffset(new DateTime(2023, 1, 9, 13, 0, 0, DateTimeKind.Utc)), ValidTo = new DateTimeOffset(new DateTime(2023, 1, 9, 20, 0, 0, DateTimeKind.Utc)), Value = 0.05m },
                     new() { ValidFrom = new DateTimeOffset(new DateTime(2023, 1, 9, 20, 0, 0, DateTimeKind.Utc)), ValidTo = new DateTimeOffset(new DateTime(2023, 1, 10, 0, 0, 0, DateTimeKind.Utc)), Value = 0.04m },
 
-                    // Tuesday prices until 4am
+                    // Tuesday until 4am
                     new() { ValidFrom = new DateTimeOffset(new DateTime(2023, 1, 10, 0, 0, 0, DateTimeKind.Utc)), ValidTo = new DateTimeOffset(new DateTime(2023, 1, 10, 3, 30, 0, DateTimeKind.Utc)), Value = 0.04m },
                     new() { ValidFrom = new DateTimeOffset(new DateTime(2023, 1, 10, 3, 30, 0, DateTimeKind.Utc)), ValidTo = new DateTimeOffset(new DateTime(2023, 1, 10, 6, 0, 0, DateTimeKind.Utc)), Value = 0.035m }
+                }
+            },
+            new object[]
+            {
+                "DayRangeWrappingAroundWeek",
+                "Europe/London",
+                new List<string>
+                {
+                    "Wed=22:00-02:00=0.05",
+                    "Wed=02:00-22:00=0.06",
+                    "Thu-Tue=0.04"
+                },
+                new DateTimeOffset(new DateTime(2023, 1, 2, 2, 0, 0, DateTimeKind.Utc)), // Monday
+                new DateTimeOffset(new DateTime(2023, 1, 5, 4, 0, 0, DateTimeKind.Utc)), // Thursday
+                new List<Price>
+                {
+                    new() { ValidFrom = new DateTimeOffset(new DateTime(2023, 1, 2, 0, 0, 0, DateTimeKind.Utc)), ValidTo = new DateTimeOffset(new DateTime(2023, 1, 3, 0, 0, 0, DateTimeKind.Utc)), Value = 0.04m },
+                    new() { ValidFrom = new DateTimeOffset(new DateTime(2023, 1, 3, 0, 0, 0, DateTimeKind.Utc)), ValidTo = new DateTimeOffset(new DateTime(2023, 1, 4, 0, 0, 0, DateTimeKind.Utc)), Value = 0.04m },
+                    new() { ValidFrom = new DateTimeOffset(new DateTime(2023, 1, 4, 0, 0, 0, DateTimeKind.Utc)), ValidTo = new DateTimeOffset(new DateTime(2023, 1, 4, 2, 0, 0, DateTimeKind.Utc)), Value = 0.05m },
+                    new() { ValidFrom = new DateTimeOffset(new DateTime(2023, 1, 4, 2, 0, 0, DateTimeKind.Utc)), ValidTo = new DateTimeOffset(new DateTime(2023, 1, 4, 22, 0, 0, DateTimeKind.Utc)), Value = 0.06m },
+                    new() { ValidFrom = new DateTimeOffset(new DateTime(2023, 1, 4, 22, 0, 0, DateTimeKind.Utc)), ValidTo = new DateTimeOffset(new DateTime(2023, 1, 5, 0, 0, 0, DateTimeKind.Utc)), Value = 0.05m },
+                    new() { ValidFrom = new DateTimeOffset(new DateTime(2023, 1, 5, 0, 0, 0, DateTimeKind.Utc)), ValidTo = new DateTimeOffset(new DateTime(2023, 1, 6, 0, 0, 0, DateTimeKind.Utc)), Value = 0.04m },
+                }
+            },
+            new object[]
+            {
+                "DifferentTimeZone",
+                "America/New_York",
+                new List<string>
+                {
+                    "Mon-Fri=08:00-13:00=0.1559",
+                    "Mon-Fri=13:00-20:00=0.05",
+                    "Mon-Fri=20:00-03:30=0.04",
+                    "Mon-Fri=03:30-06:00=0.035",
+                    "Mon-Fri=06:00-08:00=0.02",
+                    "Sat=18:00-20:00=0.05",
+                    "Sat=20:00-18:00=0.025",
+                    "Sun=0.042"
+                },
+                new DateTimeOffset(new DateTime(2023, 1, 2, 2, 0, 0, DateTimeKind.Utc)), // Monday
+                new DateTimeOffset(new DateTime(2023, 1, 4, 4, 0, 0, DateTimeKind.Utc)), // Wednesday
+                new List<Price>
+                {
+                    // Monday
+                    new() { ValidFrom = new DateTimeOffset(new DateTime(2023, 1, 2, 5, 0, 0, DateTimeKind.Utc)), ValidTo = new DateTimeOffset(new DateTime(2023, 1, 2, 8, 30, 0, DateTimeKind.Utc)), Value = 0.04m },
+                    new() { ValidFrom = new DateTimeOffset(new DateTime(2023, 1, 2, 8, 30, 0, DateTimeKind.Utc)), ValidTo = new DateTimeOffset(new DateTime(2023, 1, 2, 11, 0, 0, DateTimeKind.Utc)), Value = 0.035m },
+                    new() { ValidFrom = new DateTimeOffset(new DateTime(2023, 1, 2, 11, 0, 0, DateTimeKind.Utc)), ValidTo = new DateTimeOffset(new DateTime(2023, 1, 2, 13, 0, 0, DateTimeKind.Utc)), Value = 0.02m },
+                    new() { ValidFrom = new DateTimeOffset(new DateTime(2023, 1, 2, 13, 0, 0, DateTimeKind.Utc)), ValidTo = new DateTimeOffset(new DateTime(2023, 1, 2, 18, 0, 0, DateTimeKind.Utc)), Value = 0.1559m },
+                    new() { ValidFrom = new DateTimeOffset(new DateTime(2023, 1, 2, 18, 0, 0, DateTimeKind.Utc)), ValidTo = new DateTimeOffset(new DateTime(2023, 1, 3, 1, 0, 0, DateTimeKind.Utc)), Value = 0.05m },
+
+                    // Tuesday
+                    new() { ValidFrom = new DateTimeOffset(new DateTime(2023, 1, 3, 1, 0, 0, DateTimeKind.Utc)), ValidTo = new DateTimeOffset(new DateTime(2023, 1, 3, 5, 0, 0, DateTimeKind.Utc)), Value = 0.04m },
+                    new() { ValidFrom = new DateTimeOffset(new DateTime(2023, 1, 3, 5, 0, 0, DateTimeKind.Utc)), ValidTo = new DateTimeOffset(new DateTime(2023, 1, 3, 8, 30, 0, DateTimeKind.Utc)), Value = 0.04m },
+                    new() { ValidFrom = new DateTimeOffset(new DateTime(2023, 1, 3, 8, 30, 0, DateTimeKind.Utc)), ValidTo = new DateTimeOffset(new DateTime(2023, 1, 3, 11, 0, 0, DateTimeKind.Utc)), Value = 0.035m },
+                    new() { ValidFrom = new DateTimeOffset(new DateTime(2023, 1, 3, 11, 0, 0, DateTimeKind.Utc)), ValidTo = new DateTimeOffset(new DateTime(2023, 1, 3, 13, 0, 0, DateTimeKind.Utc)), Value = 0.02m },
+                    new() { ValidFrom = new DateTimeOffset(new DateTime(2023, 1, 3, 13, 0, 0, DateTimeKind.Utc)), ValidTo = new DateTimeOffset(new DateTime(2023, 1, 3, 18, 0, 0, DateTimeKind.Utc)), Value = 0.1559m },
+                    new() { ValidFrom = new DateTimeOffset(new DateTime(2023, 1, 3, 18, 0, 0, DateTimeKind.Utc)), ValidTo = new DateTimeOffset(new DateTime(2023, 1, 4, 1, 0, 0, DateTimeKind.Utc)), Value = 0.05m },
+
+                    // Wednesday
+                    new() { ValidFrom = new DateTimeOffset(new DateTime(2023, 1, 4, 1, 0, 0, DateTimeKind.Utc)), ValidTo = new DateTimeOffset(new DateTime(2023, 1, 4, 5, 0, 0, DateTimeKind.Utc)), Value = 0.04m }
+                }
+            },
+            new object[]
+            {
+                "TimeZoneDSTEdge",
+                "Europe/London",
+                new List<string>
+                {
+                    "Mon-Fri=08:00-13:00=0.1559",
+                    "Mon-Fri=13:00-08:00=0.234",
+                    "Sat=18:00-20:00=0.05",
+                    "Sat=20:00-18:00=0.025",
+                    "Sun=01:00-02:00=0.012",
+                    "Sun=02:00-01:00=0.044"
+                },
+                new DateTimeOffset(new DateTime(2024, 10, 25, 2, 0, 0, DateTimeKind.Utc)), // Friday before clocks go back
+                new DateTimeOffset(new DateTime(2024, 10, 29, 4, 0, 0, DateTimeKind.Utc)), // Tuesday after clocks go back
+                new List<Price>
+                {
+                    // Friday
+                    new() { ValidFrom = new DateTimeOffset(new DateTime(2024, 10, 24, 23, 0, 0, DateTimeKind.Utc)), ValidTo = new DateTimeOffset(new DateTime(2024, 10, 25, 7, 0, 0, DateTimeKind.Utc)), Value = 0.234m },
+                    new() { ValidFrom = new DateTimeOffset(new DateTime(2024, 10, 25, 7, 0, 0, DateTimeKind.Utc)), ValidTo = new DateTimeOffset(new DateTime(2024, 10, 25, 12, 0, 0, DateTimeKind.Utc)), Value = 0.1559m },
+                    new() { ValidFrom = new DateTimeOffset(new DateTime(2024, 10, 25, 12, 0, 0, DateTimeKind.Utc)), ValidTo = new DateTimeOffset(new DateTime(2024, 10, 25, 23, 0, 0, DateTimeKind.Utc)), Value = 0.234m },
+
+                    // Saturday
+                    new() { ValidFrom = new DateTimeOffset(new DateTime(2024, 10, 25, 23, 0, 0, DateTimeKind.Utc)), ValidTo = new DateTimeOffset(new DateTime(2024, 10, 26, 17, 0, 0, DateTimeKind.Utc)), Value = 0.025m },
+                    new() { ValidFrom = new DateTimeOffset(new DateTime(2024, 10, 26, 17, 0, 0, DateTimeKind.Utc)), ValidTo = new DateTimeOffset(new DateTime(2024, 10, 26, 19, 0, 0, DateTimeKind.Utc)), Value = 0.05m },
+                    new() { ValidFrom = new DateTimeOffset(new DateTime(2024, 10, 26, 19, 0, 0, DateTimeKind.Utc)), ValidTo = new DateTimeOffset(new DateTime(2024, 10, 26, 23, 0, 0, DateTimeKind.Utc)), Value = 0.025m },
+
+                    // Sunday (clocks go back 02:00->01:00)
+                    new() { ValidFrom = new DateTimeOffset(new DateTime(2024, 10, 26, 23, 0, 0, DateTimeKind.Utc)), ValidTo = new DateTimeOffset(new DateTime(2024, 10, 27, 1, 0, 0, DateTimeKind.Utc)), Value = 0.044m },
+                    new() { ValidFrom = new DateTimeOffset(new DateTime(2024, 10, 27, 1, 0, 0, DateTimeKind.Utc)), ValidTo = new DateTimeOffset(new DateTime(2024, 10, 27, 2, 0, 0, DateTimeKind.Utc)), Value = 0.012m },
+                    new() { ValidFrom = new DateTimeOffset(new DateTime(2024, 10, 27, 2, 0, 0, DateTimeKind.Utc)), ValidTo = new DateTimeOffset(new DateTime(2024, 10, 28, 0, 0, 0, DateTimeKind.Utc)), Value = 0.044m },
+
+                    // Monday
+                    new() { ValidFrom = new DateTimeOffset(new DateTime(2024, 10, 28, 0, 0, 0, DateTimeKind.Utc)), ValidTo = new DateTimeOffset(new DateTime(2024, 10, 28, 8, 0, 0, DateTimeKind.Utc)), Value = 0.234m },
+                    new() { ValidFrom = new DateTimeOffset(new DateTime(2024, 10, 28, 8, 0, 0, DateTimeKind.Utc)), ValidTo = new DateTimeOffset(new DateTime(2024, 10, 28, 13, 0, 0, DateTimeKind.Utc)), Value = 0.1559m },
+                    new() { ValidFrom = new DateTimeOffset(new DateTime(2024, 10, 28, 13, 0, 0, DateTimeKind.Utc)), ValidTo = new DateTimeOffset(new DateTime(2024, 10, 29, 0, 0, 0, DateTimeKind.Utc)), Value = 0.234m },
+
+                    // Tuesday
+                    new() { ValidFrom = new DateTimeOffset(new DateTime(2024, 10, 29, 0, 0, 0, DateTimeKind.Utc)), ValidTo = new DateTimeOffset(new DateTime(2024, 10, 29, 8, 0, 0, DateTimeKind.Utc)), Value = 0.234m }
                 }
             }
         };
@@ -116,6 +218,148 @@ namespace TeslaMateAgile.Tests.Services
                 Assert.That(actualPrice.ValidTo, Is.EqualTo(expectedPrice.ValidTo));
                 Assert.That(actualPrice.Value, Is.EqualTo(expectedPrice.Value));
             }
+        }
+
+
+        [Test]
+        public void FixedPriceWeeklyService_InvalidDays()
+        {
+            var fixedPrices = new List<string>
+            {
+                "Mon-Fri=08:00-13:00=0.1559",
+                "Mon-Fri=13:00-20:00=0.05",
+                "Mon-Fri=20:00-03:30=0.04",
+                "Mon-Fri=03:30-06:00=0.035",
+                "Mon-Fri=06:00-08:00=0.02",
+                "Sat=18:00-20:00=0.05",
+                "Sat=20:00-18:00=0.025",
+                "InvalidDay=0.042"
+            };
+            var exception = Assert.Throws<ArgumentException>(() => Setup("Europe/London", fixedPrices));
+            Assert.That(exception?.Message, Is.EqualTo("Invalid day: InvalidDay (Parameter 'day')"));
+        }
+
+        [Test]
+        public void FixedPriceWeeklyService_IncompleteWeekDays()
+        {
+            var fixedPrices = new List<string>
+            {
+                "Mon-Fri=08:00-13:00=0.1559",
+                "Mon-Fri=13:00-20:00=0.05",
+                "Mon-Fri=20:00-03:30=0.04",
+                "Mon-Fri=03:30-06:00=0.035",
+                "Mon-Fri=06:00-08:00=0.02",
+                "Sat=18:00-20:00=0.05",
+                "Sat=20:00-18:00=0.025"
+            };
+            var exception = Assert.Throws<ArgumentException>(() => Setup("Europe/London", fixedPrices));
+            Assert.That(exception?.Message, Is.EqualTo("Invalid fixed price data, does not cover the entire week"));
+        }
+
+        [Test]
+        public void FixedPriceWeeklyService_IncompleteDayHours()
+        {
+            var fixedPrices = new List<string>
+            {
+                "Mon-Fri=08:00-13:00=0.1559",
+                "Mon-Fri=13:00-20:00=0.05",
+                "Mon-Fri=20:00-03:30=0.04",
+                "Mon-Fri=03:30-06:00=0.035",
+                "Sat=18:00-20:00=0.05",
+                "Sat=20:00-18:00=0.025",
+                "Sun=0.042"
+            };
+            var exception = Assert.Throws<ArgumentException>(() => Setup("Europe/London", fixedPrices));
+            Assert.That(exception?.Message, Is.EqualTo("Invalid fixed price data, does not cover the full 24 hours"));
+        }
+
+        [Test]
+        public void FixedPriceWeeklyService_TooManyDayHours()
+        {
+            var fixedPrices = new List<string>
+            {
+                "Mon-Fri=08:00-13:00=0.1559",
+                "Mon-Fri=13:00-20:00=0.05",
+                "Mon-Fri=20:00-03:30=0.04",
+                "Mon-Fri=03:30-06:00=0.035",
+                "Mon-Fri=06:00-08:00=0.02",
+                "Sat=18:00-20:00=0.05",
+                "Sat=20:00-18:00=0.025",
+                "Sun=0.042",
+                "Mon-Fri=07:00-08:00=0.01",
+                "Mon-Fri=08:00-09:00=0.01"
+            };
+            var exception = Assert.Throws<ArgumentException>(() => Setup("Europe/London", fixedPrices));
+            Assert.That(exception?.Message, Is.EqualTo("Invalid fixed price data, covers more than 24 hours"));
+        }
+
+        [Test]
+        public void FixedPriceWeeklyService_EmptyPricesList()
+        {
+            var fixedPrices = new List<string>();
+            var exception = Assert.Throws<ArgumentException>(() => Setup("Europe/London", fixedPrices));
+            Assert.That(exception?.Message, Is.EqualTo("Invalid fixed price data, does not cover the entire week"));
+        }
+
+        [Test]
+        public void FixedPriceWeeklyService_InvalidTimeZone()
+        {
+            var fixedPrices = new List<string>
+            {
+                "Mon-Fri=08:00-13:00=0.1559"
+            };
+            var exception = Assert.Throws<ArgumentException>(() => Setup("Invalid/TimeZone", fixedPrices));
+            Assert.That(exception?.Message, Is.EqualTo("Invalid TimeZone Invalid/TimeZone (Parameter 'TimeZone')"));
+        }
+
+        [Test]
+        public void FixedPriceWeeklyService_InvalidTimeFormat()
+        {
+            var fixedPrices = new List<string>
+            {
+                "Mon=08:00-13:00=0.1559",
+                "Mon=invalid-18:00=0.05"
+            };
+            var exception = Assert.Throws<ArgumentException>(() => Setup("Europe/London", fixedPrices));
+            Assert.That(exception?.Message, Is.EqualTo("Failed to parse fixed price value: invalid-18:00=0.05 (Parameter 'value')"));
+        }
+
+        [Test]
+        public void FixedPriceWeeklyService_OverlappingTimeRanges()
+        {
+            var fixedPrices = new List<string>
+            {
+                "Mon=08:00-13:00=0.1559",
+                "Mon=12:00-18:00=0.05",
+                "Mon=18:00-07:00=0.04",
+                "Tue-Sun=0.04"
+            };
+            var exception = Assert.Throws<ArgumentException>(() => Setup("Europe/London", fixedPrices));
+            Assert.That(exception?.Message, Is.EqualTo("Invalid fixed price data, prices are not continuous"));
+        }
+
+        [Test]
+        public void FixedPriceWeeklyService_InvalidPriceFormat()
+        {
+            var fixedPrices = new List<string>
+            {
+                "Mon=08:00-13:00=invalid"
+            };
+            var exception = Assert.Throws<ArgumentException>(() => Setup("Europe/London", fixedPrices));
+            Assert.That(exception?.Message, Is.EqualTo("Failed to parse fixed price value: invalid (Parameter 'value')"));
+        }
+
+        [Test]
+        public void FixedPriceWeeklyService_InvalidTimeValues()
+        {
+            var fixedPrices = new List<string>
+            {
+                "Tue=08:60-09:00=0.05",
+                "Tue=09:00-08:60=0.04",
+                "Wed-Mon=0.10"
+            };
+            var exception = Assert.Throws<ArgumentException>(() => Setup("Europe/London", fixedPrices));
+            Assert.That(exception?.Message, Is.EqualTo("Invalid fromMinute: 60 (Parameter 'fromMinute')"));
         }
     }
 }

--- a/TeslaMateAgile.Tests/Services/FixedPriceWeeklyServiceTests.cs
+++ b/TeslaMateAgile.Tests/Services/FixedPriceWeeklyServiceTests.cs
@@ -1,17 +1,13 @@
-using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Threading.Tasks;
 using Microsoft.Extensions.Options;
 using NUnit.Framework;
+using TeslaMateAgile.Data;
 using TeslaMateAgile.Data.Options;
 using TeslaMateAgile.Services;
-using TeslaMateAgile.Data; // Added the necessary using directive for the `Price` type
 
 namespace TeslaMateAgile.Tests.Services
 {
     [TestFixture]
-    public class FixedPriceWeeklyServiceTests
+    public class FixedPriceWeeklyServiceTestsTest
     {
         private FixedPriceWeeklyService Setup(string timeZone, List<string> prices)
         {
@@ -34,60 +30,71 @@ namespace TeslaMateAgile.Tests.Services
                     "Mon-Fri=06:00-08:00=0.02",
                     "Sat=18:00-20:00=0.05",
                     "Sat=20:00-18:00=0.025",
-                    "Sun=0.04"
+                    "Sun=0.042"
                 },
-                new DateTimeOffset(new DateTime(2023, 1, 2, 0, 0, 0, DateTimeKind.Utc)), // Monday
-                new DateTimeOffset(new DateTime(2023, 1, 9, 0, 0, 0, DateTimeKind.Utc)), // Next Monday
+                new DateTimeOffset(new DateTime(2023, 1, 2, 2, 0, 0, DateTimeKind.Utc)), // Monday
+                new DateTimeOffset(new DateTime(2023, 1, 10, 4, 0, 0, DateTimeKind.Utc)), // Next Tuesday
                 new List<Price>
                 {
-                    new Price
-                    {
-                        ValidFrom = new DateTimeOffset(new DateTime(2023, 1, 2, 8, 0, 0, DateTimeKind.Utc)),
-                        ValidTo = new DateTimeOffset(new DateTime(2023, 1, 2, 13, 0, 0, DateTimeKind.Utc)),
-                        Value = 0.1559m
-                    },
-                    new Price
-                    {
-                        ValidFrom = new DateTimeOffset(new DateTime(2023, 1, 2, 13, 0, 0, DateTimeKind.Utc)),
-                        ValidTo = new DateTimeOffset(new DateTime(2023, 1, 2, 20, 0, 0, DateTimeKind.Utc)),
-                        Value = 0.05m
-                    },
-                    new Price
-                    {
-                        ValidFrom = new DateTimeOffset(new DateTime(2023, 1, 2, 20, 0, 0, DateTimeKind.Utc)),
-                        ValidTo = new DateTimeOffset(new DateTime(2023, 1, 3, 3, 30, 0, DateTimeKind.Utc)),
-                        Value = 0.04m
-                    },
-                    new Price
-                    {
-                        ValidFrom = new DateTimeOffset(new DateTime(2023, 1, 3, 3, 30, 0, DateTimeKind.Utc)),
-                        ValidTo = new DateTimeOffset(new DateTime(2023, 1, 3, 6, 0, 0, DateTimeKind.Utc)),
-                        Value = 0.035m
-                    },
-                    new Price
-                    {
-                        ValidFrom = new DateTimeOffset(new DateTime(2023, 1, 3, 6, 0, 0, DateTimeKind.Utc)),
-                        ValidTo = new DateTimeOffset(new DateTime(2023, 1, 3, 8, 0, 0, DateTimeKind.Utc)),
-                        Value = 0.02m
-                    },
-                    new Price
-                    {
-                        ValidFrom = new DateTimeOffset(new DateTime(2023, 1, 7, 18, 0, 0, DateTimeKind.Utc)),
-                        ValidTo = new DateTimeOffset(new DateTime(2023, 1, 7, 20, 0, 0, DateTimeKind.Utc)),
-                        Value = 0.05m
-                    },
-                    new Price
-                    {
-                        ValidFrom = new DateTimeOffset(new DateTime(2023, 1, 7, 20, 0, 0, DateTimeKind.Utc)),
-                        ValidTo = new DateTimeOffset(new DateTime(2023, 1, 8, 18, 0, 0, DateTimeKind.Utc)),
-                        Value = 0.025m
-                    },
-                    new Price
-                    {
-                        ValidFrom = new DateTimeOffset(new DateTime(2023, 1, 8, 0, 0, 0, DateTimeKind.Utc)),
-                        ValidTo = new DateTimeOffset(new DateTime(2023, 1, 9, 0, 0, 0, DateTimeKind.Utc)),
-                        Value = 0.04m
-                    }
+                    // Monday prices from 2am
+                    new() { ValidFrom = new DateTimeOffset(new DateTime(2023, 1, 2, 0, 0, 0, DateTimeKind.Utc)), ValidTo = new DateTimeOffset(new DateTime(2023, 1, 2, 3, 30, 0, DateTimeKind.Utc)), Value = 0.04m },
+                    new() { ValidFrom = new DateTimeOffset(new DateTime(2023, 1, 2, 3, 30, 0, DateTimeKind.Utc)), ValidTo = new DateTimeOffset(new DateTime(2023, 1, 2, 6, 0, 0, DateTimeKind.Utc)), Value = 0.035m },
+                    new() { ValidFrom = new DateTimeOffset(new DateTime(2023, 1, 2, 6, 0, 0, DateTimeKind.Utc)), ValidTo = new DateTimeOffset(new DateTime(2023, 1, 2, 8, 0, 0, DateTimeKind.Utc)), Value = 0.02m },
+                    new() { ValidFrom = new DateTimeOffset(new DateTime(2023, 1, 2, 8, 0, 0, DateTimeKind.Utc)), ValidTo = new DateTimeOffset(new DateTime(2023, 1, 2, 13, 0, 0, DateTimeKind.Utc)), Value = 0.1559m },
+                    new() { ValidFrom = new DateTimeOffset(new DateTime(2023, 1, 2, 13, 0, 0, DateTimeKind.Utc)), ValidTo = new DateTimeOffset(new DateTime(2023, 1, 2, 20, 0, 0, DateTimeKind.Utc)), Value = 0.05m },
+                    new() { ValidFrom = new DateTimeOffset(new DateTime(2023, 1, 2, 20, 0, 0, DateTimeKind.Utc)), ValidTo = new DateTimeOffset(new DateTime(2023, 1, 3, 0, 0, 0, DateTimeKind.Utc)), Value = 0.04m },
+
+                    // Tuesday prices
+                    new() { ValidFrom = new DateTimeOffset(new DateTime(2023, 1, 3, 0, 0, 0, DateTimeKind.Utc)), ValidTo = new DateTimeOffset(new DateTime(2023, 1, 3, 3, 30, 0, DateTimeKind.Utc)), Value = 0.04m },
+                    new() { ValidFrom = new DateTimeOffset(new DateTime(2023, 1, 3, 3, 30, 0, DateTimeKind.Utc)), ValidTo = new DateTimeOffset(new DateTime(2023, 1, 3, 6, 0, 0, DateTimeKind.Utc)), Value = 0.035m },
+                    new() { ValidFrom = new DateTimeOffset(new DateTime(2023, 1, 3, 6, 0, 0, DateTimeKind.Utc)), ValidTo = new DateTimeOffset(new DateTime(2023, 1, 3, 8, 0, 0, DateTimeKind.Utc)), Value = 0.02m },
+                    new() { ValidFrom = new DateTimeOffset(new DateTime(2023, 1, 3, 8, 0, 0, DateTimeKind.Utc)), ValidTo = new DateTimeOffset(new DateTime(2023, 1, 3, 13, 0, 0, DateTimeKind.Utc)), Value = 0.1559m },
+                    new() { ValidFrom = new DateTimeOffset(new DateTime(2023, 1, 3, 13, 0, 0, DateTimeKind.Utc)), ValidTo = new DateTimeOffset(new DateTime(2023, 1, 3, 20, 0, 0, DateTimeKind.Utc)), Value = 0.05m },
+                    new() { ValidFrom = new DateTimeOffset(new DateTime(2023, 1, 3, 20, 0, 0, DateTimeKind.Utc)), ValidTo = new DateTimeOffset(new DateTime(2023, 1, 4, 0, 0, 0, DateTimeKind.Utc)), Value = 0.04m },
+
+                    // Wednesday prices
+                    new() { ValidFrom = new DateTimeOffset(new DateTime(2023, 1, 4, 0, 0, 0, DateTimeKind.Utc)), ValidTo = new DateTimeOffset(new DateTime(2023, 1, 4, 3, 30, 0, DateTimeKind.Utc)), Value = 0.04m },
+                    new() { ValidFrom = new DateTimeOffset(new DateTime(2023, 1, 4, 3, 30, 0, DateTimeKind.Utc)), ValidTo = new DateTimeOffset(new DateTime(2023, 1, 4, 6, 0, 0, DateTimeKind.Utc)), Value = 0.035m },
+                    new() { ValidFrom = new DateTimeOffset(new DateTime(2023, 1, 4, 6, 0, 0, DateTimeKind.Utc)), ValidTo = new DateTimeOffset(new DateTime(2023, 1, 4, 8, 0, 0, DateTimeKind.Utc)), Value = 0.02m },
+                    new() { ValidFrom = new DateTimeOffset(new DateTime(2023, 1, 4, 8, 0, 0, DateTimeKind.Utc)), ValidTo = new DateTimeOffset(new DateTime(2023, 1, 4, 13, 0, 0, DateTimeKind.Utc)), Value = 0.1559m },
+                    new() { ValidFrom = new DateTimeOffset(new DateTime(2023, 1, 4, 13, 0, 0, DateTimeKind.Utc)), ValidTo = new DateTimeOffset(new DateTime(2023, 1, 4, 20, 0, 0, DateTimeKind.Utc)), Value = 0.05m },
+                    new() { ValidFrom = new DateTimeOffset(new DateTime(2023, 1, 4, 20, 0, 0, DateTimeKind.Utc)), ValidTo = new DateTimeOffset(new DateTime(2023, 1, 5, 0, 0, 0, DateTimeKind.Utc)), Value = 0.04m },
+
+                    // Thursday prices
+                    new() { ValidFrom = new DateTimeOffset(new DateTime(2023, 1, 5, 0, 0, 0, DateTimeKind.Utc)), ValidTo = new DateTimeOffset(new DateTime(2023, 1, 5, 3, 30, 0, DateTimeKind.Utc)), Value = 0.04m },
+                    new() { ValidFrom = new DateTimeOffset(new DateTime(2023, 1, 5, 3, 30, 0, DateTimeKind.Utc)), ValidTo = new DateTimeOffset(new DateTime(2023, 1, 5, 6, 0, 0, DateTimeKind.Utc)), Value = 0.035m },
+                    new() { ValidFrom = new DateTimeOffset(new DateTime(2023, 1, 5, 6, 0, 0, DateTimeKind.Utc)), ValidTo = new DateTimeOffset(new DateTime(2023, 1, 5, 8, 0, 0, DateTimeKind.Utc)), Value = 0.02m },
+                    new() { ValidFrom = new DateTimeOffset(new DateTime(2023, 1, 5, 8, 0, 0, DateTimeKind.Utc)), ValidTo = new DateTimeOffset(new DateTime(2023, 1, 5, 13, 0, 0, DateTimeKind.Utc)), Value = 0.1559m },
+                    new() { ValidFrom = new DateTimeOffset(new DateTime(2023, 1, 5, 13, 0, 0, DateTimeKind.Utc)), ValidTo = new DateTimeOffset(new DateTime(2023, 1, 5, 20, 0, 0, DateTimeKind.Utc)), Value = 0.05m },
+                    new() { ValidFrom = new DateTimeOffset(new DateTime(2023, 1, 5, 20, 0, 0, DateTimeKind.Utc)), ValidTo = new DateTimeOffset(new DateTime(2023, 1, 6, 0, 0, 0, DateTimeKind.Utc)), Value = 0.04m },
+
+                    // Friday prices
+                    new() { ValidFrom = new DateTimeOffset(new DateTime(2023, 1, 6, 0, 0, 0, DateTimeKind.Utc)), ValidTo = new DateTimeOffset(new DateTime(2023, 1, 6, 3, 30, 0, DateTimeKind.Utc)), Value = 0.04m },
+                    new() { ValidFrom = new DateTimeOffset(new DateTime(2023, 1, 6, 3, 30, 0, DateTimeKind.Utc)), ValidTo = new DateTimeOffset(new DateTime(2023, 1, 6, 6, 0, 0, DateTimeKind.Utc)), Value = 0.035m },
+                    new() { ValidFrom = new DateTimeOffset(new DateTime(2023, 1, 6, 6, 0, 0, DateTimeKind.Utc)), ValidTo = new DateTimeOffset(new DateTime(2023, 1, 6, 8, 0, 0, DateTimeKind.Utc)), Value = 0.02m },
+                    new() { ValidFrom = new DateTimeOffset(new DateTime(2023, 1, 6, 8, 0, 0, DateTimeKind.Utc)), ValidTo = new DateTimeOffset(new DateTime(2023, 1, 6, 13, 0, 0, DateTimeKind.Utc)), Value = 0.1559m },
+                    new() { ValidFrom = new DateTimeOffset(new DateTime(2023, 1, 6, 13, 0, 0, DateTimeKind.Utc)), ValidTo = new DateTimeOffset(new DateTime(2023, 1, 6, 20, 0, 0, DateTimeKind.Utc)), Value = 0.05m },
+                    new() { ValidFrom = new DateTimeOffset(new DateTime(2023, 1, 6, 20, 0, 0, DateTimeKind.Utc)), ValidTo = new DateTimeOffset(new DateTime(2023, 1, 7, 0, 0, 0, DateTimeKind.Utc)), Value = 0.04m },
+
+                    // Saturday prices
+                    new() { ValidFrom = new DateTimeOffset(new DateTime(2023, 1, 7, 0, 0, 0, DateTimeKind.Utc)), ValidTo = new DateTimeOffset(new DateTime(2023, 1, 7, 18, 0, 0, DateTimeKind.Utc)), Value = 0.025m },
+                    new() { ValidFrom = new DateTimeOffset(new DateTime(2023, 1, 7, 18, 0, 0, DateTimeKind.Utc)), ValidTo = new DateTimeOffset(new DateTime(2023, 1, 7, 20, 0, 0, DateTimeKind.Utc)), Value = 0.05m },
+                    new() { ValidFrom = new DateTimeOffset(new DateTime(2023, 1, 7, 20, 0, 0, DateTimeKind.Utc)), ValidTo = new DateTimeOffset(new DateTime(2023, 1, 8, 0, 0, 0, DateTimeKind.Utc)), Value = 0.025m },
+
+                    // Sunday prices
+                    new() { ValidFrom = new DateTimeOffset(new DateTime(2023, 1, 8, 0, 0, 0, DateTimeKind.Utc)), ValidTo = new DateTimeOffset(new DateTime(2023, 1, 9, 0, 0, 0, DateTimeKind.Utc)), Value = 0.042m },
+
+                    // Monday prices
+                    new() { ValidFrom = new DateTimeOffset(new DateTime(2023, 1, 9, 0, 0, 0, DateTimeKind.Utc)), ValidTo = new DateTimeOffset(new DateTime(2023, 1, 9, 3, 30, 0, DateTimeKind.Utc)), Value = 0.04m },
+                    new() { ValidFrom = new DateTimeOffset(new DateTime(2023, 1, 9, 3, 30, 0, DateTimeKind.Utc)), ValidTo = new DateTimeOffset(new DateTime(2023, 1, 9, 6, 0, 0, DateTimeKind.Utc)), Value = 0.035m },
+                    new() { ValidFrom = new DateTimeOffset(new DateTime(2023, 1, 9, 6, 0, 0, DateTimeKind.Utc)), ValidTo = new DateTimeOffset(new DateTime(2023, 1, 9, 8, 0, 0, DateTimeKind.Utc)), Value = 0.02m },
+                    new() { ValidFrom = new DateTimeOffset(new DateTime(2023, 1, 9, 8, 0, 0, DateTimeKind.Utc)), ValidTo = new DateTimeOffset(new DateTime(2023, 1, 9, 13, 0, 0, DateTimeKind.Utc)), Value = 0.1559m },
+                    new() { ValidFrom = new DateTimeOffset(new DateTime(2023, 1, 9, 13, 0, 0, DateTimeKind.Utc)), ValidTo = new DateTimeOffset(new DateTime(2023, 1, 9, 20, 0, 0, DateTimeKind.Utc)), Value = 0.05m },
+                    new() { ValidFrom = new DateTimeOffset(new DateTime(2023, 1, 9, 20, 0, 0, DateTimeKind.Utc)), ValidTo = new DateTimeOffset(new DateTime(2023, 1, 10, 0, 0, 0, DateTimeKind.Utc)), Value = 0.04m },
+
+                    // Tuesday prices until 4am
+                    new() { ValidFrom = new DateTimeOffset(new DateTime(2023, 1, 10, 0, 0, 0, DateTimeKind.Utc)), ValidTo = new DateTimeOffset(new DateTime(2023, 1, 10, 3, 30, 0, DateTimeKind.Utc)), Value = 0.04m },
+                    new() { ValidFrom = new DateTimeOffset(new DateTime(2023, 1, 10, 3, 30, 0, DateTimeKind.Utc)), ValidTo = new DateTimeOffset(new DateTime(2023, 1, 10, 6, 0, 0, DateTimeKind.Utc)), Value = 0.035m }
                 }
             }
         };
@@ -99,15 +106,15 @@ namespace TeslaMateAgile.Tests.Services
             var fixedPriceWeeklyService = Setup(timeZone, fixedPrices);
             var result = await fixedPriceWeeklyService.GetPriceData(from, to);
             var actualPrices = result.OrderBy(x => x.ValidFrom).ToList();
-            Assert.That(expectedPrices.Count, Is.EqualTo(actualPrices.Count()));
+            Assert.That(actualPrices.Count(), Is.EqualTo(expectedPrices.Count));
             for (var i = 0; i < actualPrices.Count(); i++)
             {
                 var actualPrice = actualPrices[i];
                 var expectedPrice = expectedPrices[i];
 
-                Assert.That(expectedPrice.ValidFrom, Is.EqualTo(actualPrice.ValidFrom));
-                Assert.That(expectedPrice.ValidTo, Is.EqualTo(actualPrice.ValidTo));
-                Assert.That(expectedPrice.Value, Is.EqualTo(actualPrice.Value));
+                Assert.That(actualPrice.ValidFrom, Is.EqualTo(expectedPrice.ValidFrom));
+                Assert.That(actualPrice.ValidTo, Is.EqualTo(expectedPrice.ValidTo));
+                Assert.That(actualPrice.Value, Is.EqualTo(expectedPrice.Value));
             }
         }
     }

--- a/TeslaMateAgile.Tests/Services/FixedPriceWeeklyServiceTests.cs
+++ b/TeslaMateAgile.Tests/Services/FixedPriceWeeklyServiceTests.cs
@@ -1,0 +1,114 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using Microsoft.Extensions.Options;
+using NUnit.Framework;
+using TeslaMateAgile.Data.Options;
+using TeslaMateAgile.Services;
+using TeslaMateAgile.Data; // Added the necessary using directive for the `Price` type
+
+namespace TeslaMateAgile.Tests.Services
+{
+    [TestFixture]
+    public class FixedPriceWeeklyServiceTests
+    {
+        private FixedPriceWeeklyService Setup(string timeZone, List<string> prices)
+        {
+            var options = Options.Create(new FixedPriceWeeklyOptions { TimeZone = timeZone, Prices = prices });
+            return new FixedPriceWeeklyService(options);
+        }
+
+        private static readonly object[][] FixedPriceWeeklyService_GetPriceData_Cases = new object[][]
+        {
+            new object[]
+            {
+                "WeekdaysAndWeekend",
+                "Europe/London",
+                new List<string>
+                {
+                    "Mon-Fri=08:00-13:00=0.1559",
+                    "Mon-Fri=13:00-20:00=0.05",
+                    "Mon-Fri=20:00-03:30=0.04",
+                    "Mon-Fri=03:30-06:00=0.035",
+                    "Mon-Fri=06:00-08:00=0.02",
+                    "Sat=18:00-20:00=0.05",
+                    "Sat=20:00-18:00=0.025",
+                    "Sun=0.04"
+                },
+                new DateTimeOffset(new DateTime(2023, 1, 2, 0, 0, 0, DateTimeKind.Utc)), // Monday
+                new DateTimeOffset(new DateTime(2023, 1, 9, 0, 0, 0, DateTimeKind.Utc)), // Next Monday
+                new List<Price>
+                {
+                    new Price
+                    {
+                        ValidFrom = new DateTimeOffset(new DateTime(2023, 1, 2, 8, 0, 0, DateTimeKind.Utc)),
+                        ValidTo = new DateTimeOffset(new DateTime(2023, 1, 2, 13, 0, 0, DateTimeKind.Utc)),
+                        Value = 0.1559m
+                    },
+                    new Price
+                    {
+                        ValidFrom = new DateTimeOffset(new DateTime(2023, 1, 2, 13, 0, 0, DateTimeKind.Utc)),
+                        ValidTo = new DateTimeOffset(new DateTime(2023, 1, 2, 20, 0, 0, DateTimeKind.Utc)),
+                        Value = 0.05m
+                    },
+                    new Price
+                    {
+                        ValidFrom = new DateTimeOffset(new DateTime(2023, 1, 2, 20, 0, 0, DateTimeKind.Utc)),
+                        ValidTo = new DateTimeOffset(new DateTime(2023, 1, 3, 3, 30, 0, DateTimeKind.Utc)),
+                        Value = 0.04m
+                    },
+                    new Price
+                    {
+                        ValidFrom = new DateTimeOffset(new DateTime(2023, 1, 3, 3, 30, 0, DateTimeKind.Utc)),
+                        ValidTo = new DateTimeOffset(new DateTime(2023, 1, 3, 6, 0, 0, DateTimeKind.Utc)),
+                        Value = 0.035m
+                    },
+                    new Price
+                    {
+                        ValidFrom = new DateTimeOffset(new DateTime(2023, 1, 3, 6, 0, 0, DateTimeKind.Utc)),
+                        ValidTo = new DateTimeOffset(new DateTime(2023, 1, 3, 8, 0, 0, DateTimeKind.Utc)),
+                        Value = 0.02m
+                    },
+                    new Price
+                    {
+                        ValidFrom = new DateTimeOffset(new DateTime(2023, 1, 7, 18, 0, 0, DateTimeKind.Utc)),
+                        ValidTo = new DateTimeOffset(new DateTime(2023, 1, 7, 20, 0, 0, DateTimeKind.Utc)),
+                        Value = 0.05m
+                    },
+                    new Price
+                    {
+                        ValidFrom = new DateTimeOffset(new DateTime(2023, 1, 7, 20, 0, 0, DateTimeKind.Utc)),
+                        ValidTo = new DateTimeOffset(new DateTime(2023, 1, 8, 18, 0, 0, DateTimeKind.Utc)),
+                        Value = 0.025m
+                    },
+                    new Price
+                    {
+                        ValidFrom = new DateTimeOffset(new DateTime(2023, 1, 8, 0, 0, 0, DateTimeKind.Utc)),
+                        ValidTo = new DateTimeOffset(new DateTime(2023, 1, 9, 0, 0, 0, DateTimeKind.Utc)),
+                        Value = 0.04m
+                    }
+                }
+            }
+        };
+
+        [Test, TestCaseSource(nameof(FixedPriceWeeklyService_GetPriceData_Cases))]
+        public async Task FixedPriceWeeklyService_GetPriceData(string testName, string timeZone, List<string> fixedPrices, DateTimeOffset from, DateTimeOffset to, List<Price> expectedPrices)
+        {
+            Console.WriteLine($"Running get price data test '{testName}'");
+            var fixedPriceWeeklyService = Setup(timeZone, fixedPrices);
+            var result = await fixedPriceWeeklyService.GetPriceData(from, to);
+            var actualPrices = result.OrderBy(x => x.ValidFrom).ToList();
+            Assert.That(expectedPrices.Count, Is.EqualTo(actualPrices.Count()));
+            for (var i = 0; i < actualPrices.Count(); i++)
+            {
+                var actualPrice = actualPrices[i];
+                var expectedPrice = expectedPrices[i];
+
+                Assert.That(expectedPrice.ValidFrom, Is.EqualTo(actualPrice.ValidFrom));
+                Assert.That(expectedPrice.ValidTo, Is.EqualTo(actualPrice.ValidTo));
+                Assert.That(expectedPrice.Value, Is.EqualTo(actualPrice.Value));
+            }
+        }
+    }
+}

--- a/TeslaMateAgile/Data/Enums/EnergyProvider.cs
+++ b/TeslaMateAgile/Data/Enums/EnergyProvider.cs
@@ -5,6 +5,7 @@ public enum EnergyProvider
     Octopus,
     Tibber,
     FixedPrice,
+    FixedPriceWeekly,
     Awattar,
     Energinet,
     HomeAssistant,

--- a/TeslaMateAgile/Data/Options/FixedPriceWeeklyOptions.cs
+++ b/TeslaMateAgile/Data/Options/FixedPriceWeeklyOptions.cs
@@ -1,0 +1,12 @@
+using System.ComponentModel.DataAnnotations;
+
+namespace TeslaMateAgile.Data.Options;
+
+public class FixedPriceWeeklyOptions
+{
+    [Required]
+    public string TimeZone { get; set; }
+
+    [Required]
+    public List<string> Prices { get; set; }
+}

--- a/TeslaMateAgile/Program.cs
+++ b/TeslaMateAgile/Program.cs
@@ -125,6 +125,14 @@ public class Program
                        .ValidateOnStart();
                     services.AddSingleton<IPriceDataService, FixedPriceService>();
                 }
+                else if (energyProvider == EnergyProvider.FixedPriceWeekly)
+                {
+                    services.AddOptions<FixedPriceWeeklyOptions>()
+                       .Bind(config.GetSection("FixedPriceWeekly"))
+                       .ValidateDataAnnotations()
+                       .ValidateOnStart();
+                    services.AddSingleton<IPriceDataService, FixedPriceWeeklyService>();
+                }
                 else if (energyProvider == EnergyProvider.Awattar)
                 {
                     services.AddOptions<AwattarOptions>()

--- a/TeslaMateAgile/Program.cs
+++ b/TeslaMateAgile/Program.cs
@@ -72,7 +72,7 @@ public class Program
                         }
                         else
                         {
-                            throw new ArgumentException(databasePortVariable, $"Configuration '{databasePortVariable}' is invalid, must be an integer");
+                            throw new ArgumentException($"Configuration '{databasePortVariable}' is invalid, must be an integer", databasePortVariable);
                         }
                     }
 

--- a/TeslaMateAgile/Services/FixedPriceService.cs
+++ b/TeslaMateAgile/Services/FixedPriceService.cs
@@ -15,11 +15,11 @@ public class FixedPriceService : IDynamicPriceDataService
         IOptions<FixedPriceOptions> options
         )
     {
-        _fixedPrices = GetFixedPrices(options.Value);
         if (!TZConvert.TryGetTimeZoneInfo(options.Value.TimeZone, out _timeZone))
         {
-            throw new ArgumentException(nameof(options.Value.TimeZone), $"Invalid TimeZone {options.Value.TimeZone}");
+            throw new ArgumentException($"Invalid TimeZone {options.Value.TimeZone}", nameof(options.Value.TimeZone));
         }
+        _fixedPrices = GetFixedPrices(options.Value);
     }
 
     public Task<IEnumerable<Price>> GetPriceData(DateTimeOffset from, DateTimeOffset to)
@@ -85,7 +85,7 @@ public class FixedPriceService : IDynamicPriceDataService
         foreach (var price in options.Prices.OrderBy(x => x))
         {
             var match = FixedPriceRegex.Match(price);
-            if (!match.Success) { throw new ArgumentException(nameof(price), $"Failed to parse fixed price: {price}"); }
+            if (!match.Success) { throw new ArgumentException($"Failed to parse fixed price: {price}", nameof(price)); }
             var fromHour = int.Parse(match.Groups[1].Value);
             var fromMinute = int.Parse(match.Groups[2].Value);
             var toHour = int.Parse(match.Groups[3].Value);
@@ -113,14 +113,14 @@ public class FixedPriceService : IDynamicPriceDataService
 
             if (lastFixedPrice != null && (fixedPrice.FromHour != lastFixedPrice.ToHour || fixedPrice.FromMinute != lastFixedPrice.ToMinute))
             {
-                throw new ArgumentException(nameof(price), $"Price from time does not match previous to time: {price}");
+                throw new ArgumentException($"Price from time does not match previous to time: {price}", nameof(price));
             }
             totalHours += toHours - fromHours;
             lastFixedPrice = fixedPrice;
         }
         if (totalHours != 24)
         {
-            throw new ArgumentException(nameof(totalHours), $"Total hours do not equal 24, currently {totalHours}");
+            throw new ArgumentException($"Total hours do not equal 24, currently {totalHours}", nameof(totalHours));
         }
         return fixedPrices;
     }

--- a/TeslaMateAgile/Services/FixedPriceWeeklyService.cs
+++ b/TeslaMateAgile/Services/FixedPriceWeeklyService.cs
@@ -1,0 +1,155 @@
+using Microsoft.Extensions.Options;
+using System.Text.RegularExpressions;
+using TeslaMateAgile.Data;
+using TeslaMateAgile.Data.Options;
+using TeslaMateAgile.Services.Interfaces;
+using TimeZoneConverter;
+
+namespace TeslaMateAgile.Services;
+
+public class FixedPriceWeeklyService : IDynamicPriceDataService
+{
+    private readonly List<FixedPriceWeekly> _fixedPrices;
+
+    public FixedPriceWeeklyService(
+        IOptions<FixedPriceWeeklyOptions> options
+        )
+    {
+        _fixedPrices = GetFixedPrices(options.Value);
+        if (!TZConvert.TryGetTimeZoneInfo(options.Value.TimeZone, out _timeZone))
+        {
+            throw new ArgumentException(nameof(options.Value.TimeZone), $"Invalid TimeZone {options.Value.TimeZone}");
+        }
+    }
+
+    public Task<IEnumerable<Price>> GetPriceData(DateTimeOffset from, DateTimeOffset to)
+    {
+        var prices = new List<Price>();
+        var started = false;
+        var dayIndex = -1;
+        int fpIndex = 0;
+        var maxIterations = 100; // fail-safe against infinite loop
+        for (var i = 0; i <= maxIterations; i++)
+        {
+            var fixedPrice = _fixedPrices[fpIndex];
+            var validFrom = DateTime.SpecifyKind(from.Date.AddDays(dayIndex).AddHours(fixedPrice.FromHour).AddMinutes(fixedPrice.FromMinute), DateTimeKind.Utc);
+            var validTo = DateTime.SpecifyKind(from.Date.AddDays(dayIndex).AddHours(fixedPrice.ToHour).AddMinutes(fixedPrice.ToMinute), DateTimeKind.Utc);
+            var price = new Price
+            {
+                ValidFrom = validFrom.Add(-_timeZone.GetUtcOffset(validFrom)),
+                ValidTo = validTo.Add(-_timeZone.GetUtcOffset(validTo)),
+                Value = fixedPrice.Value
+            };
+            if (price.ValidFrom < to && price.ValidTo > from)
+            {
+                prices.Add(price);
+                started = true;
+            }
+            else if (started)
+            {
+                break;
+            }
+            fpIndex++;
+            if (fpIndex >= _fixedPrices.Count)
+            {
+                fpIndex = 0;
+                dayIndex++;
+            }
+            if (i == maxIterations)
+            {
+                throw new Exception("Infinite loop detected within FixedPriceWeekly provider");
+            }
+        }
+
+        return Task.FromResult(prices.AsEnumerable());
+    }
+
+    private class FixedPriceWeekly
+    {
+        public int FromHour { get; set; }
+        public int FromMinute { get; set; }
+        public int ToHour { get; set; }
+        public int ToMinute { get; set; }
+        public decimal Value { get; set; }
+        public List<DayOfWeek> Days { get; set; }
+    }
+
+    private static readonly Regex FixedPriceWeeklyRegex = new Regex("(?<days>[a-zA-Z,-]+)=(?<fromHour>\\d\\d):(?<fromMinute>\\d\\d)-(?<toHour>\\d\\d):(?<toMinute>\\d\\d)=(?<value>.+)");
+    private readonly TimeZoneInfo _timeZone;
+
+    private List<FixedPriceWeekly> GetFixedPrices(FixedPriceWeeklyOptions options)
+    {
+        var fixedPrices = new List<FixedPriceWeekly>();
+
+        foreach (var price in options.Prices.OrderBy(x => x))
+        {
+            var match = FixedPriceWeeklyRegex.Match(price);
+            if (!match.Success) { throw new ArgumentException(nameof(price), $"Failed to parse fixed price: {price}"); }
+            var fromHour = int.Parse(match.Groups["fromHour"].Value);
+            var fromMinute = int.Parse(match.Groups["fromMinute"].Value);
+            var toHour = int.Parse(match.Groups["toHour"].Value);
+            var toMinute = int.Parse(match.Groups["toMinute"].Value);
+            if (!decimal.TryParse(match.Groups["value"].Value, out var value))
+            {
+                throw new ArgumentException(nameof(value), $"Failed to parse fixed price value: {match.Groups["value"].Value}");
+            }
+
+            var days = ParseDays(match.Groups["days"].Value);
+
+            var fixedPrice = new FixedPriceWeekly
+            {
+                FromHour = fromHour,
+                FromMinute = fromMinute,
+                ToHour = toHour,
+                ToMinute = toMinute,
+                Value = value,
+                Days = days
+            };
+            fixedPrices.Add(fixedPrice);
+        }
+
+        return fixedPrices;
+    }
+
+    private List<DayOfWeek> ParseDays(string days)
+    {
+        var dayList = new List<DayOfWeek>();
+        var dayRanges = days.Split(',');
+
+        foreach (var dayRange in dayRanges)
+        {
+            if (dayRange.Contains('-'))
+            {
+                var rangeParts = dayRange.Split('-');
+                var startDay = ParseDay(rangeParts[0]);
+                var endDay = ParseDay(rangeParts[1]);
+
+                for (var day = startDay; day <= endDay; day++)
+                {
+                    dayList.Add((DayOfWeek)day);
+                }
+            }
+            else
+            {
+                dayList.Add(ParseDay(dayRange));
+            }
+        }
+
+        return dayList;
+    }
+
+    private DayOfWeek ParseDay(string day)
+    {
+        return day.ToLower() switch
+        {
+            "mon" => DayOfWeek.Monday,
+            "tue" => DayOfWeek.Tuesday,
+            "wed" => DayOfWeek.Wednesday,
+            "thu" => DayOfWeek.Thursday,
+            "fri" => DayOfWeek.Friday,
+            "sat" => DayOfWeek.Saturday,
+            "sun" => DayOfWeek.Sunday,
+            _ => throw new ArgumentException(nameof(day), $"Invalid day: {day}")
+        };
+    }
+}


### PR DESCRIPTION
The FixedPriceWeekly provider is a variant on the FixedPrice provider which allows you to set fixed pricing per time of day, but also per day of week and any combination of that. 