### PR TITLE
Skip non-numeric HA history states

### DIFF
--- a/TeslaMateAgile.Tests/Prices/ha_test_leading_unavailable.json
+++ b/TeslaMateAgile.Tests/Prices/ha_test_leading_unavailable.json
@@ -1,0 +1,25 @@
+[
+  [
+    {
+      "entity_id": "sensor.tesla_effective_price",
+      "state": "unavailable",
+      "attributes": {},
+      "last_changed": "2023-08-24T23:43:53+00:00",
+      "last_updated": "2023-08-24T23:43:53+00:00"
+    },
+    {
+      "entity_id": "sensor.tesla_effective_price",
+      "state": "0.0095",
+      "attributes": {},
+      "last_changed": "2023-08-24T23:43:53.025000+00:00",
+      "last_updated": "2023-08-24T23:43:53.025000+00:00"
+    },
+    {
+      "entity_id": "sensor.tesla_effective_price",
+      "state": "0.0100",
+      "attributes": {},
+      "last_changed": "2023-08-25T01:00:00+00:00",
+      "last_updated": "2023-08-25T01:00:00+00:00"
+    }
+  ]
+]

--- a/TeslaMateAgile.Tests/Prices/ha_test_non_numeric_states.json
+++ b/TeslaMateAgile.Tests/Prices/ha_test_non_numeric_states.json
@@ -1,0 +1,46 @@
+[
+  [
+    {
+      "entity_id": "sensor.tesla_effective_price",
+      "state": "0.0095",
+      "attributes": {},
+      "last_changed": "2023-08-24T23:43:53+00:00",
+      "last_updated": "2023-08-24T23:43:53+00:00"
+    },
+    {
+      "entity_id": "sensor.tesla_effective_price",
+      "state": "0.0096",
+      "attributes": {},
+      "last_changed": "2023-08-25T00:30:00+00:00",
+      "last_updated": "2023-08-25T00:30:00+00:00"
+    },
+    {
+      "entity_id": "sensor.tesla_effective_price",
+      "state": "unavailable",
+      "attributes": {},
+      "last_changed": "2023-08-25T01:17:53.891919+00:00",
+      "last_updated": "2023-08-25T01:17:53.891919+00:00"
+    },
+    {
+      "entity_id": "sensor.tesla_effective_price",
+      "state": "0.0098",
+      "attributes": {},
+      "last_changed": "2023-08-25T01:17:53.916159+00:00",
+      "last_updated": "2023-08-25T01:17:53.916159+00:00"
+    },
+    {
+      "entity_id": "sensor.tesla_effective_price",
+      "state": "unknown",
+      "attributes": {},
+      "last_changed": "2023-08-25T02:00:00+00:00",
+      "last_updated": "2023-08-25T02:00:00+00:00"
+    },
+    {
+      "entity_id": "sensor.tesla_effective_price",
+      "state": "0.0100",
+      "attributes": {},
+      "last_changed": "2023-08-25T02:00:00.025000+00:00",
+      "last_updated": "2023-08-25T02:00:00.025000+00:00"
+    }
+  ]
+]

--- a/TeslaMateAgile.Tests/Services/HomeAssistantServiceTests.cs
+++ b/TeslaMateAgile.Tests/Services/HomeAssistantServiceTests.cs
@@ -66,7 +66,6 @@ public class HomeAssistantServiceTests
 
         // 6 entries in the JSON, 2 are non-numeric (unavailable, unknown) → 4 prices
         Assert.That(priceList.Count, Is.EqualTo(4));
-        Assert.That(priceList.All(p => p.Value > 0), Is.True, "All prices should be numeric and positive");
 
         // Verify the unavailable/unknown entries were skipped and time ranges are correct
         // The price before 'unavailable' should extend to the next valid entry's timestamp

--- a/TeslaMateAgile.Tests/Services/HomeAssistantServiceTests.cs
+++ b/TeslaMateAgile.Tests/Services/HomeAssistantServiceTests.cs
@@ -50,4 +50,32 @@ public class HomeAssistantServiceTests
         Assert.That(priceList[0].ValidTo, Is.EqualTo(endDate));
         Assert.That(priceList[0].Value, Is.EqualTo(0.2748M));
     }
+
+    [Test]
+    public async Task Filters_Non_Numeric_States()
+    {
+        var json = File.ReadAllText(Path.Combine("Prices", "ha_test_non_numeric_states.json"));
+
+        _handler.SetupAnyRequest()
+            .ReturnsResponse(json, "application/json");
+
+        var startDate = DateTimeOffset.Parse("2023-08-24T23:43:53Z");
+        var endDate = DateTimeOffset.Parse("2023-08-25T03:19:42Z");
+        var priceData = await _subject.GetPriceData(startDate, endDate);
+        var priceList = priceData.Prices.ToList();
+
+        // 6 entries in the JSON, 2 are non-numeric (unavailable, unknown) → 4 prices
+        Assert.That(priceList.Count, Is.EqualTo(4));
+        Assert.That(priceList.All(p => p.Value > 0), Is.True, "All prices should be numeric and positive");
+
+        // Verify the unavailable/unknown entries were skipped and time ranges are correct
+        // The price before 'unavailable' should extend to the next valid entry's timestamp
+        Assert.That(priceList[0].Value, Is.EqualTo(0.0095M));
+        Assert.That(priceList[1].Value, Is.EqualTo(0.0096M));
+        Assert.That(priceList[1].ValidTo, Is.EqualTo(priceList[2].ValidFrom),
+            "Price interval should bridge over the filtered unavailable entry");
+        Assert.That(priceList[2].Value, Is.EqualTo(0.0098M));
+        Assert.That(priceList[3].Value, Is.EqualTo(0.0100M));
+        Assert.That(priceList[3].ValidTo, Is.EqualTo(endDate));
+    }
 }

--- a/TeslaMateAgile.Tests/Services/HomeAssistantServiceTests.cs
+++ b/TeslaMateAgile.Tests/Services/HomeAssistantServiceTests.cs
@@ -78,4 +78,26 @@ public class HomeAssistantServiceTests
         Assert.That(priceList[3].Value, Is.EqualTo(0.0100M));
         Assert.That(priceList[3].ValidTo, Is.EqualTo(endDate));
     }
+
+    [Test]
+    public async Task Extends_First_Price_When_Leading_Entries_Filtered()
+    {
+        var json = File.ReadAllText(Path.Combine("Prices", "ha_test_leading_unavailable.json"));
+
+        _handler.SetupAnyRequest()
+            .ReturnsResponse(json, "application/json");
+
+        var startDate = DateTimeOffset.Parse("2023-08-24T23:43:53Z");
+        var endDate = DateTimeOffset.Parse("2023-08-25T03:19:42Z");
+        var priceData = await _subject.GetPriceData(startDate, endDate);
+        var priceList = priceData.Prices.ToList();
+
+        // First entry is unavailable, so the first valid price should extend back to cover startDate
+        Assert.That(priceList.Count, Is.EqualTo(2));
+        Assert.That(priceList[0].ValidFrom, Is.EqualTo(startDate),
+            "First price should extend back to the requested start date");
+        Assert.That(priceList[0].Value, Is.EqualTo(0.0095M));
+        Assert.That(priceList[1].Value, Is.EqualTo(0.0100M));
+        Assert.That(priceList[1].ValidTo, Is.EqualTo(endDate));
+    }
 }

--- a/TeslaMateAgile/Services/HomeAssistantService.cs
+++ b/TeslaMateAgile/Services/HomeAssistantService.cs
@@ -56,7 +56,8 @@ public class HomeAssistantService : IDynamicPriceDataService
         {
             var state = history[i];
             var price = decimal.Parse(state.State, CultureInfo.InvariantCulture);
-            var validFrom = state.LastUpdated;
+            // If leading entries were filtered, extend the first valid price to cover from the start
+            var validFrom = (i == 0) ? from : state.LastUpdated;
             var validTo = (i < history.Count - 1) ? history[i + 1].LastUpdated : to;
 
             prices.Add(new Price

--- a/TeslaMateAgile/Services/HomeAssistantService.cs
+++ b/TeslaMateAgile/Services/HomeAssistantService.cs
@@ -1,4 +1,5 @@
-﻿using Microsoft.Extensions.Logging;
+﻿using System.Globalization;
+using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
 using System.Text.Json;
 using System.Text.Json.Serialization;
@@ -40,7 +41,7 @@ public class HomeAssistantService : IDynamicPriceDataService
         }
 
         // Skip non-numeric states (e.g. "unavailable", "unknown") from HA history
-        var numericHistory = history.Where(h => decimal.TryParse(h.State, out _)).ToList();
+        var numericHistory = history.Where(h => decimal.TryParse(h.State, NumberStyles.Number, CultureInfo.InvariantCulture, out _)).ToList();
         if (!numericHistory.Any())
         {
             throw new Exception($"No numeric price data from Home Assistant for entity id {_options.EntityId} in date range {from.UtcDateTime:o} to {to.UtcDateTime:o}");
@@ -54,7 +55,7 @@ public class HomeAssistantService : IDynamicPriceDataService
         for (var i = 0; i < history.Count; i++)
         {
             var state = history[i];
-            var price = decimal.Parse(state.State);
+            var price = decimal.Parse(state.State, CultureInfo.InvariantCulture);
             var validFrom = state.LastUpdated;
             var validTo = (i < history.Count - 1) ? history[i + 1].LastUpdated : to;
 

--- a/TeslaMateAgile/Services/HomeAssistantService.cs
+++ b/TeslaMateAgile/Services/HomeAssistantService.cs
@@ -38,10 +38,18 @@ public class HomeAssistantService : IDynamicPriceDataService
         {
             throw new Exception($"No data from Home Assistant for entity id {_options.EntityId}, ensure it and {nameof(TeslaMateOptions.LookbackDays)} are set correctly");
         }
-        if (history.First().LastUpdated != from)
+
+        // Skip non-numeric states (e.g. "unavailable", "unknown") from HA history
+        var numericHistory = history.Where(h => decimal.TryParse(h.State, out _)).ToList();
+        if (!numericHistory.Any())
+        {
+            throw new Exception($"No numeric price data from Home Assistant for entity id {_options.EntityId} in date range {from.UtcDateTime:o} to {to.UtcDateTime:o}");
+        }
+        if (numericHistory.Count == history.Count && numericHistory.First().LastUpdated != from)
         {
             throw new Exception($"Home Assistant has incomplete data for date range {from.UtcDateTime:o} to {to.UtcDateTime:o}, ensure entity and {nameof(TeslaMateOptions.LookbackDays)} are set correctly");
         }
+        history = numericHistory;
         var prices = new List<Price>();
         for (var i = 0; i < history.Count; i++)
         {

--- a/TeslaMateAgile/Services/HomeAssistantService.cs
+++ b/TeslaMateAgile/Services/HomeAssistantService.cs
@@ -40,15 +40,16 @@ public class HomeAssistantService : IDynamicPriceDataService
             throw new Exception($"No data from Home Assistant for entity id {_options.EntityId}, ensure it and {nameof(TeslaMateOptions.LookbackDays)} are set correctly");
         }
 
+        if (history.First().LastUpdated != from)
+        {
+            throw new Exception($"Home Assistant has incomplete data for date range {from.UtcDateTime:o} to {to.UtcDateTime:o}, ensure entity and {nameof(TeslaMateOptions.LookbackDays)} are set correctly");
+        }
+
         // Skip non-numeric states (e.g. "unavailable", "unknown") from HA history
         var numericHistory = history.Where(h => decimal.TryParse(h.State, NumberStyles.Number, CultureInfo.InvariantCulture, out _)).ToList();
         if (!numericHistory.Any())
         {
             throw new Exception($"No numeric price data from Home Assistant for entity id {_options.EntityId} in date range {from.UtcDateTime:o} to {to.UtcDateTime:o}");
-        }
-        if (numericHistory.Count == history.Count && numericHistory.First().LastUpdated != from)
-        {
-            throw new Exception($"Home Assistant has incomplete data for date range {from.UtcDateTime:o} to {to.UtcDateTime:o}, ensure entity and {nameof(TeslaMateOptions.LookbackDays)} are set correctly");
         }
         history = numericHistory;
         var prices = new List<Price>();


### PR DESCRIPTION
I use a Home Assistant template sensor as my energy price entity. During HA restarts and template reloads, these sensors briefly flash to `unavailable` or `unknown` (typically ~25ms) before recovering. The HA history API faithfully records these blips, and `decimal.Parse()` in `GetPriceData` throws a `FormatException` on them, permanently failing the cost calculation for any charging session that overlaps.

This filters out non-numeric states from the HA history before processing prices. The previous valid price naturally extends through the gap. Includes a test.

I saw #49 was closed with the `input_number` workaround and the concern that ignoring `unavailable` states could result in silent inaccurate measurements. I think in practice this isn't really a concern because the existing pricing logic already assumes the previous value holds until the next update. Each history entry's price extends forward until the next entry's timestamp (`validTo = history[i+1].LastUpdated`). Filtering out a 25ms `unavailable` blip is identical behaviour to if HA simply hadn't recorded that blip at all. The alternative right now is that a single millisecond of `unavailable` causes the entire charging session to permanently fail with no cost calculated, which is a much worse outcome than a negligible rounding difference from a brief gap.

The `input_number` workaround also doesn't really help for template sensors. They flash `unavailable` during every HA restart or template reload by design, there's no way to prevent it. Asking every template sensor user to maintain a parallel `input_number` and automation feels like an unreasonable workaround for what is essentially a parsing issue.